### PR TITLE
selected dropdown option not always displaying right

### DIFF
--- a/crouton.php
+++ b/crouton.php
@@ -896,7 +896,8 @@ if (!class_exists("Crouton")) {
 										<?php $area_parent = $area_data[2]; ?>
 										<?php $area_parent_name = $area_data[3]; ?>
 										<?php $option_description = $area_name . " (" . $area_id . ") " . $area_parent_name . " (" . $area_parent . ")" ?></option>
-										<?php if ($unique_area == $this->options['service_body_1']) { ?>
+										<?php $is_data = explode(',',esc_html($this->options['service_body_1'])); ?>
+										<?php if ( $area_id == $is_data[1] ) { ?>
 											<option selected="selected" value="<?php echo $unique_area; ?>"><?php echo $option_description; ?></option>
 										<?php } else { ?>
 											<option value="<?php echo $unique_area; ?>"><?php echo $option_description; ?></option>

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,9 @@ Crouton is a "Fork" of the BMLT Tabbed UI plugin. This plugin provides a Tabbed 
 
 == Changelog ==
 
+= UNRELEASED =
+* Selected dropdown option not always being respected for new searchable dropdown, however selected option was.
+
 = 2.2.0 =
 * Add chosen for searchable dropdown service body config. [#60]
 


### PR DESCRIPTION
the selected dropdown option wasn't always displaying depending on certain characters in service body name. the option would save correctly and work but the selected value wouldn't display on dropdown. this is how bread does it and escaping them should fix this. found this when saving "Martha's Vineyard" didn't like the apostrophe and the selected value would default to the first (in my case Boston). This issue did exist in previous versions and was not newly introduced.

Ref. #64 